### PR TITLE
fix batch size defaults to None in eval mode

### DIFF
--- a/gan/Styleformer/config.py
+++ b/gan/Styleformer/config.py
@@ -139,17 +139,18 @@ def update_config(config, args):
     config.defrost()
     if args.dataset:
         config.DATA.DATASET = args.dataset
+    if args.eval:
+        config.EVAL = True
     if args.batch_size:
         config.DATA.BATCH_SIZE = args.batch_size
+        if config.EVAL:
+            config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.image_size:
         config.DATA.IMAGE_SIZE = args.image_size
     if args.data_path:
         config.DATA.DATA_PATH = args.data_path
     if args.ngpus:
         config.NGPUS = args.ngpus
-    if args.eval:
-        config.EVAL = True
-        config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.pretrained:
         config.MODEL.PRETRAINED = args.pretrained
     # if args.resume:

--- a/gan/transGAN/config.py
+++ b/gan/transGAN/config.py
@@ -131,17 +131,18 @@ def update_config(config, args):
     config.defrost()
     if args.dataset:
         config.DATA.DATASET = args.dataset
+    if args.eval:
+        config.EVAL = True
     if args.batch_size:
         config.DATA.BATCH_SIZE = args.batch_size
+        if config.EVAL:
+            config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.image_size:
         config.DATA.IMAGE_SIZE = args.image_size
     if args.data_path:
         config.DATA.DATA_PATH = args.data_path
     if args.ngpus:
         config.NGPUS = args.ngpus
-    if args.eval:
-        config.EVAL = True
-        config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.pretrained:
         config.MODEL.PRETRAINED = args.pretrained
     if args.resume:

--- a/image_classification/BEiT/config.py
+++ b/image_classification/BEiT/config.py
@@ -152,8 +152,12 @@ def update_config(config, args):
     config.defrost()
     if args.dataset:
         config.DATA.DATASET = args.dataset
+    if args.eval:
+        config.EVAL = True
     if args.batch_size:
         config.DATA.BATCH_SIZE = args.batch_size
+        if config.EVAL:
+            config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.image_size:
         config.DATA.IMAGE_SIZE = args.image_size
     if args.data_path:
@@ -162,9 +166,6 @@ def update_config(config, args):
         config.SAVE = args.output
     if args.ngpus:
         config.NGPUS = args.ngpus
-    if args.eval:
-        config.EVAL = True
-        config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.pretrained:
         config.MODEL.PRETRAINED = args.pretrained
     if args.resume:

--- a/image_classification/BoTNet/config.py
+++ b/image_classification/BoTNet/config.py
@@ -141,8 +141,12 @@ def update_config(config, args):
     config.defrost()
     if args.dataset:
         config.DATA.DATASET = args.dataset
+    if args.eval:
+        config.EVAL = True
     if args.batch_size:
         config.DATA.BATCH_SIZE = args.batch_size
+        if config.EVAL:
+            config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.image_size:
         config.DATA.IMAGE_SIZE = args.image_size
     if args.data_path:
@@ -151,9 +155,6 @@ def update_config(config, args):
         config.SAVE = args.output
     if args.ngpus:
         config.NGPUS = args.ngpus
-    if args.eval:
-        config.EVAL = True
-        config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.pretrained:
         config.MODEL.PRETRAINED = args.pretrained
     if args.resume:

--- a/image_classification/CSwin/config.py
+++ b/image_classification/CSwin/config.py
@@ -156,8 +156,12 @@ def update_config(config, args):
     config.defrost()
     if args.dataset:
         config.DATA.DATASET = args.dataset
+    if args.eval:
+        config.EVAL = True
     if args.batch_size:
         config.DATA.BATCH_SIZE = args.batch_size
+        if config.EVAL:
+            config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.image_size:
         config.DATA.IMAGE_SIZE = args.image_size
     if args.data_path:
@@ -166,9 +170,6 @@ def update_config(config, args):
         config.SAVE = args.output
     if args.ngpus:
         config.NGPUS = args.ngpus
-    if args.eval:
-        config.EVAL = True
-        config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.pretrained:
         config.MODEL.PRETRAINED = args.pretrained
     if args.resume:

--- a/image_classification/CaiT/config.py
+++ b/image_classification/CaiT/config.py
@@ -123,8 +123,12 @@ def update_config(config, args):
     config.defrost()
     if args.dataset:
         config.DATA.DATASET = args.dataset
+    if args.eval:
+        config.EVAL = True
     if args.batch_size:
         config.DATA.BATCH_SIZE = args.batch_size
+        if config.EVAL:
+            config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.image_size:
         config.DATA.IMAGE_SIZE = args.image_size
     if args.data_path:
@@ -133,9 +137,6 @@ def update_config(config, args):
         config.SAVE = args.output
     if args.ngpus:
         config.NGPUS = args.ngpus
-    if args.eval:
-        config.EVAL = True
-        config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.pretrained:
         config.MODEL.PRETRAINED = args.pretrained
     if args.resume:

--- a/image_classification/ConvMLP/config.py
+++ b/image_classification/ConvMLP/config.py
@@ -153,8 +153,12 @@ def update_config(config, args):
     config.defrost()
     if args.dataset:
         config.DATA.DATASET = args.dataset
+    if args.eval:
+        config.EVAL = True
     if args.batch_size:
         config.DATA.BATCH_SIZE = args.batch_size
+        if config.EVAL:
+            config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.image_size:
         config.DATA.IMAGE_SIZE = args.image_size
     if args.data_path:
@@ -163,9 +167,6 @@ def update_config(config, args):
         config.SAVE = args.output
     if args.ngpus:
         config.NGPUS = args.ngpus
-    if args.eval:
-        config.EVAL = True
-        config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.pretrained:
         config.MODEL.PRETRAINED = args.pretrained
     if args.resume:

--- a/image_classification/ConvMixer/config.py
+++ b/image_classification/ConvMixer/config.py
@@ -151,8 +151,12 @@ def update_config(config, args):
     config.defrost()
     if args.dataset:
         config.DATA.DATASET = args.dataset
+    if args.eval:
+        config.EVAL = True
     if args.batch_size:
         config.DATA.BATCH_SIZE = args.batch_size
+        if config.EVAL:
+            config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.image_size:
         config.DATA.IMAGE_SIZE = args.image_size
     if args.data_path:
@@ -161,9 +165,6 @@ def update_config(config, args):
         config.SAVE = args.output
     if args.ngpus:
         config.NGPUS = args.ngpus
-    if args.eval:
-        config.EVAL = True
-        config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.pretrained:
         config.MODEL.PRETRAINED = args.pretrained
     if args.resume:

--- a/image_classification/CrossViT/config.py
+++ b/image_classification/CrossViT/config.py
@@ -129,8 +129,12 @@ def update_config(config, args):
     config.defrost()
     if args.dataset:
         config.DATA.DATASET = args.dataset
+    if args.eval:
+        config.EVAL = True
     if args.batch_size:
         config.DATA.BATCH_SIZE = args.batch_size
+        if config.EVAL:
+            config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.image_size:
         config.DATA.IMAGE_SIZE = args.image_size
     if args.data_path:
@@ -139,9 +143,6 @@ def update_config(config, args):
         config.SAVE = args.output
     if args.ngpus:
         config.NGPUS = args.ngpus
-    if args.eval:
-        config.EVAL = True
-        config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.pretrained:
         config.MODEL.PRETRAINED = args.pretrained
     if args.resume:

--- a/image_classification/CvT/config.py
+++ b/image_classification/CvT/config.py
@@ -153,8 +153,12 @@ def update_config(config, args):
     config.defrost()
     if args.dataset:
         config.DATA.DATASET = args.dataset
+    if args.eval:
+        config.EVAL = True
     if args.batch_size:
         config.DATA.BATCH_SIZE = args.batch_size
+        if config.EVAL:
+            config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.image_size:
         config.DATA.IMAGE_SIZE = args.image_size
     if args.data_path:
@@ -163,9 +167,6 @@ def update_config(config, args):
         config.SAVE = args.output
     if args.ngpus:
         config.NGPUS = args.ngpus
-    if args.eval:
-        config.EVAL = True
-        config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.pretrained:
         config.MODEL.PRETRAINED = args.pretrained
     if args.resume:

--- a/image_classification/CycleMLP/config.py
+++ b/image_classification/CycleMLP/config.py
@@ -147,8 +147,12 @@ def update_config(config, args):
     config.defrost()
     if args.dataset:
         config.DATA.DATASET = args.dataset
+    if args.eval:
+        config.EVAL = True
     if args.batch_size:
         config.DATA.BATCH_SIZE = args.batch_size
+        if config.EVAL:
+            config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.image_size:
         config.DATA.IMAGE_SIZE = args.image_size
     if args.data_path:
@@ -157,9 +161,6 @@ def update_config(config, args):
         config.SAVE = args.output
     if args.ngpus:
         config.NGPUS = args.ngpus
-    if args.eval:
-        config.EVAL = True
-        config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.pretrained:
         config.MODEL.PRETRAINED = args.pretrained
     if args.resume:

--- a/image_classification/DeiT/config.py
+++ b/image_classification/DeiT/config.py
@@ -161,8 +161,12 @@ def update_config(config, args):
     config.defrost()
     if args.dataset:
         config.DATA.DATASET = args.dataset
+    if args.eval:
+        config.EVAL = True
     if args.batch_size:
         config.DATA.BATCH_SIZE = args.batch_size
+        if config.EVAL:
+            config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.image_size:
         config.DATA.IMAGE_SIZE = args.image_size
     if args.data_path:
@@ -171,9 +175,6 @@ def update_config(config, args):
         config.SAVE = args.output
     if args.ngpus:
         config.NGPUS = args.ngpus
-    if args.eval:
-        config.EVAL = True
-        config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.pretrained:
         config.MODEL.PRETRAINED = args.pretrained
     if args.resume:

--- a/image_classification/FF_Only/config.py
+++ b/image_classification/FF_Only/config.py
@@ -144,8 +144,12 @@ def update_config(config, args):
     config.defrost()
     if args.dataset:
         config.DATA.DATASET = args.dataset
+    if args.eval:
+        config.EVAL = True
     if args.batch_size:
         config.DATA.BATCH_SIZE = args.batch_size
+        if config.EVAL:
+            config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.image_size:
         config.DATA.IMAGE_SIZE = args.image_size
     if args.data_path:
@@ -154,9 +158,6 @@ def update_config(config, args):
         config.SAVE = args.output
     if args.ngpus:
         config.NGPUS = args.ngpus
-    if args.eval:
-        config.EVAL = True
-        config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.pretrained:
         config.MODEL.PRETRAINED = args.pretrained
     if args.resume:

--- a/image_classification/Focal_Transformer/config.py
+++ b/image_classification/Focal_Transformer/config.py
@@ -185,8 +185,12 @@ def update_config(config, args):
     # merge from specific arguments
     if args.dataset:
         config.DATA.DATASET = args.dataset
+    if args.eval:
+        config.EVAL = True
     if args.batch_size:
         config.DATA.BATCH_SIZE = args.batch_size
+        if config.EVAL:
+            config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.image_size:
         config.DATA.IMAGE_SIZE = args.image_size
     if args.num_classes:
@@ -195,9 +199,6 @@ def update_config(config, args):
         config.DATA.DATA_PATH = args.data_path
     if args.ngpus:
         config.NGPUS = args.ngpus
-    if args.eval:
-        config.EVAL = True
-        config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.pretrained:
         config.MODEL.PRETRAINED = args.pretrained
     if args.resume:

--- a/image_classification/HVT/config.py
+++ b/image_classification/HVT/config.py
@@ -164,17 +164,18 @@ def update_config(config, args):
     config.defrost()
     if args.dataset:
         config.DATA.DATASET = args.dataset
+    if args.eval:
+        config.EVAL = True
     if args.batch_size:
         config.DATA.BATCH_SIZE = args.batch_size
+        if config.EVAL:
+            config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.image_size:
         config.DATA.IMAGE_SIZE = args.image_size
     if args.data_path:
         config.DATA.DATA_PATH = args.data_path
     if args.ngpus:
         config.NGPUS = args.ngpus
-    if args.eval:
-        config.EVAL = True
-        config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.pretrained:
         config.MODEL.PRETRAINED = args.pretrained
     if args.resume:

--- a/image_classification/HaloNet/config.py
+++ b/image_classification/HaloNet/config.py
@@ -158,8 +158,12 @@ def update_config(config, args):
     config.defrost()
     if args.dataset:
         config.DATA.DATASET = args.dataset
+    if args.eval:
+        config.EVAL = True
     if args.batch_size:
         config.DATA.BATCH_SIZE = args.batch_size
+        if config.EVAL:
+            config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.image_size:
         config.DATA.IMAGE_SIZE = args.image_size
     if args.data_path:
@@ -168,9 +172,6 @@ def update_config(config, args):
         config.SAVE = args.output
     if args.ngpus:
         config.NGPUS = args.ngpus
-    if args.eval:
-        config.EVAL = True
-        config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.pretrained:
         config.MODEL.PRETRAINED = args.pretrained
     if args.resume:

--- a/image_classification/MAE/config.py
+++ b/image_classification/MAE/config.py
@@ -145,8 +145,12 @@ def update_config(config, args):
     config.defrost()
     if args.dataset:
         config.DATA.DATASET = args.dataset
+    if args.eval:
+        config.EVAL = True
     if args.batch_size:
         config.DATA.BATCH_SIZE = args.batch_size
+        if config.EVAL:
+            config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.image_size:
         config.DATA.IMAGE_SIZE = args.image_size
     if args.data_path:
@@ -155,9 +159,6 @@ def update_config(config, args):
         config.SAVE = args.output
     if args.ngpus:
         config.NGPUS = args.ngpus
-    if args.eval:
-        config.EVAL = True
-        config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.pretrained:
         config.MODEL.PRETRAINED = args.pretrained
     if args.mae_pretrain:

--- a/image_classification/MLP-Mixer/config.py
+++ b/image_classification/MLP-Mixer/config.py
@@ -116,8 +116,12 @@ def update_config(config, args):
     config.defrost()
     if args.dataset:
         config.DATA.DATASET = args.dataset
+    if args.eval:
+        config.EVAL = True
     if args.batch_size:
         config.DATA.BATCH_SIZE = args.batch_size
+        if config.EVAL:
+            config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.image_size:
         config.DATA.IMAGE_SIZE = args.image_size
     if args.data_path:
@@ -126,9 +130,6 @@ def update_config(config, args):
         config.SAVE = args.output
     if args.ngpus:
         config.NGPUS = args.ngpus
-    if args.eval:
-        config.EVAL = True
-        config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.pretrained:
         config.MODEL.PRETRAINED = args.pretrained
     if args.resume:

--- a/image_classification/MobileFormer/config.py
+++ b/image_classification/MobileFormer/config.py
@@ -193,8 +193,12 @@ def update_config(config, args):
         config.MODEL.MF.TYPE = args.model_type
     if args.dataset:
         config.DATA.DATASET = args.dataset
+    if args.eval:
+        config.EVAL = True
     if args.batch_size:
         config.DATA.BATCH_SIZE = args.batch_size
+        if config.EVAL:
+            config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.image_size:
         config.DATA.IMAGE_SIZE = args.image_size
     if args.num_classes:
@@ -203,9 +207,6 @@ def update_config(config, args):
         config.DATA.DATA_PATH = args.data_path
     if args.ngpus:
         config.NGPUS = args.ngpus
-    if args.eval:
-        config.EVAL = True
-        config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.pretrained:
         config.MODEL.PRETRAINED = args.pretrained
     if args.resume:

--- a/image_classification/MobileViT/config.py
+++ b/image_classification/MobileViT/config.py
@@ -156,8 +156,12 @@ def update_config(config, args):
     config.defrost()
     if args.dataset:
         config.DATA.DATASET = args.dataset
+    if args.eval:
+        config.EVAL = True
     if args.batch_size:
         config.DATA.BATCH_SIZE = args.batch_size
+        if config.EVAL:
+            config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.image_size:
         config.DATA.IMAGE_SIZE = args.image_size
     if args.data_path:
@@ -166,9 +170,6 @@ def update_config(config, args):
         config.SAVE = args.output
     if args.ngpus:
         config.NGPUS = args.ngpus
-    if args.eval:
-        config.EVAL = True
-        config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.pretrained:
         config.MODEL.PRETRAINED = args.pretrained
     if args.resume:

--- a/image_classification/PVTv2/config.py
+++ b/image_classification/PVTv2/config.py
@@ -158,8 +158,12 @@ def update_config(config, args):
     config.defrost()
     if args.dataset:
         config.DATA.DATASET = args.dataset
+    if args.eval:
+        config.EVAL = True
     if args.batch_size:
         config.DATA.BATCH_SIZE = args.batch_size
+        if config.EVAL:
+            config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.image_size:
         config.DATA.IMAGE_SIZE = args.image_size
     if args.data_path:
@@ -168,9 +172,6 @@ def update_config(config, args):
         config.SAVE = args.output
     if args.ngpus:
         config.NGPUS = args.ngpus
-    if args.eval:
-        config.EVAL = True
-        config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.pretrained:
         config.MODEL.PRETRAINED = args.pretrained
     if args.resume:

--- a/image_classification/PiT/config.py
+++ b/image_classification/PiT/config.py
@@ -164,8 +164,12 @@ def update_config(config, args):
     config.defrost()
     if args.dataset:
         config.DATA.DATASET = args.dataset
+    if args.eval:
+        config.EVAL = True
     if args.batch_size:
         config.DATA.BATCH_SIZE = args.batch_size
+        if config.EVAL:
+            config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.image_size:
         config.DATA.IMAGE_SIZE = args.image_size
     if args.data_path:
@@ -174,9 +178,6 @@ def update_config(config, args):
         config.SAVE = args.output
     if args.ngpus:
         config.NGPUS = args.ngpus
-    if args.eval:
-        config.EVAL = True
-        config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.pretrained:
         config.MODEL.PRETRAINED = args.pretrained
     if args.resume:

--- a/image_classification/PoolFormer/config.py
+++ b/image_classification/PoolFormer/config.py
@@ -153,8 +153,12 @@ def update_config(config, args):
     config.defrost()
     if args.dataset:
         config.DATA.DATASET = args.dataset
+    if args.eval:
+        config.EVAL = True
     if args.batch_size:
         config.DATA.BATCH_SIZE = args.batch_size
+        if config.EVAL:
+            config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.image_size:
         config.DATA.IMAGE_SIZE = args.image_size
     if args.data_path:
@@ -163,9 +167,6 @@ def update_config(config, args):
         config.SAVE = args.output
     if args.ngpus:
         config.NGPUS = args.ngpus
-    if args.eval:
-        config.EVAL = True
-        config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.pretrained:
         config.MODEL.PRETRAINED = args.pretrained
     if args.resume:

--- a/image_classification/RepMLP/config.py
+++ b/image_classification/RepMLP/config.py
@@ -154,8 +154,12 @@ def update_config(config, args):
     config.defrost()
     if args.dataset:
         config.DATA.DATASET = args.dataset
+    if args.eval:
+        config.EVAL = True
     if args.batch_size:
         config.DATA.BATCH_SIZE = args.batch_size
+        if config.EVAL:
+            config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.image_size:
         config.DATA.IMAGE_SIZE = args.image_size
     if args.data_path:
@@ -164,9 +168,6 @@ def update_config(config, args):
         config.SAVE = args.output
     if args.ngpus:
         config.NGPUS = args.ngpus
-    if args.eval:
-        config.EVAL = True
-        config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.pretrained:
         config.MODEL.PRETRAINED = args.pretrained
     if args.resume:

--- a/image_classification/ResMLP/config.py
+++ b/image_classification/ResMLP/config.py
@@ -116,8 +116,12 @@ def update_config(config, args):
     config.defrost()
     if args.dataset:
         config.DATA.DATASET = args.dataset
+    if args.eval:
+        config.EVAL = True
     if args.batch_size:
         config.DATA.BATCH_SIZE = args.batch_size
+        if config.EVAL:
+            config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.image_size:
         config.DATA.IMAGE_SIZE = args.image_size
     if args.data_path:
@@ -126,9 +130,6 @@ def update_config(config, args):
         config.SAVE = args.output
     if args.ngpus:
         config.NGPUS = args.ngpus
-    if args.eval:
-        config.EVAL = True
-        config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.pretrained:
         config.MODEL.PRETRAINED = args.pretrained
     if args.resume:

--- a/image_classification/Shuffle_Transformer/config.py
+++ b/image_classification/Shuffle_Transformer/config.py
@@ -157,8 +157,12 @@ def update_config(config, args):
     config.defrost()
     if args.dataset:
         config.DATA.DATASET = args.dataset
+    if args.eval:
+        config.EVAL = True
     if args.batch_size:
         config.DATA.BATCH_SIZE = args.batch_size
+        if config.EVAL:
+            config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.image_size:
         config.DATA.IMAGE_SIZE = args.image_size
     if args.data_path:
@@ -167,9 +171,6 @@ def update_config(config, args):
         config.SAVE = args.output
     if args.ngpus:
         config.NGPUS = args.ngpus
-    if args.eval:
-        config.EVAL = True
-        config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.pretrained:
         config.MODEL.PRETRAINED = args.pretrained
     if args.resume:

--- a/image_classification/SwinTransformer/config.py
+++ b/image_classification/SwinTransformer/config.py
@@ -157,8 +157,12 @@ def update_config(config, args):
     config.defrost()
     if args.dataset:
         config.DATA.DATASET = args.dataset
+    if args.eval:
+        config.EVAL = True
     if args.batch_size:
         config.DATA.BATCH_SIZE = args.batch_size
+        if config.EVAL:
+            config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.image_size:
         config.DATA.IMAGE_SIZE = args.image_size
     if args.data_path:
@@ -167,9 +171,6 @@ def update_config(config, args):
         config.SAVE = args.output
     if args.ngpus:
         config.NGPUS = args.ngpus
-    if args.eval:
-        config.EVAL = True
-        config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.pretrained:
         config.MODEL.PRETRAINED = args.pretrained
     if args.resume:

--- a/image_classification/T2T_ViT/config.py
+++ b/image_classification/T2T_ViT/config.py
@@ -154,8 +154,12 @@ def update_config(config, args):
     config.defrost()
     if args.dataset:
         config.DATA.DATASET = args.dataset
+    if args.eval:
+        config.EVAL = True
     if args.batch_size:
         config.DATA.BATCH_SIZE = args.batch_size
+        if config.EVAL:
+            config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.image_size:
         config.DATA.IMAGE_SIZE = args.image_size
     if args.data_path:
@@ -164,9 +168,6 @@ def update_config(config, args):
         config.SAVE = args.output
     if args.ngpus:
         config.NGPUS = args.ngpus
-    if args.eval:
-        config.EVAL = True
-        config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.pretrained:
         config.MODEL.PRETRAINED = args.pretrained
     if args.resume:

--- a/image_classification/VOLO/config.py
+++ b/image_classification/VOLO/config.py
@@ -125,8 +125,12 @@ def update_config(config, args):
     config.defrost()
     if args.dataset:
         config.DATA.DATASET = args.dataset
+    if args.eval:
+        config.EVAL = True
     if args.batch_size:
         config.DATA.BATCH_SIZE = args.batch_size
+        if config.EVAL:
+            config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.image_size:
         config.DATA.IMAGE_SIZE = args.image_size
     if args.data_path:
@@ -135,9 +139,6 @@ def update_config(config, args):
         config.SAVE = args.output
     if args.ngpus:
         config.NGPUS = args.ngpus
-    if args.eval:
-        config.EVAL = True
-        config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.pretrained:
         config.MODEL.PRETRAINED = args.pretrained
     if args.resume:

--- a/image_classification/ViP/config.py
+++ b/image_classification/ViP/config.py
@@ -151,8 +151,12 @@ def update_config(config, args):
     config.defrost()
     if args.dataset:
         config.DATA.DATASET = args.dataset
+    if args.eval:
+        config.EVAL = True
     if args.batch_size:
         config.DATA.BATCH_SIZE = args.batch_size
+        if config.EVAL:
+            config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.image_size:
         config.DATA.IMAGE_SIZE = args.image_size
     if args.data_path:
@@ -161,9 +165,6 @@ def update_config(config, args):
         config.SAVE = args.output
     if args.ngpus:
         config.NGPUS = args.ngpus
-    if args.eval:
-        config.EVAL = True
-        config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.pretrained:
         config.MODEL.PRETRAINED = args.pretrained
     if args.resume:

--- a/image_classification/ViT/config.py
+++ b/image_classification/ViT/config.py
@@ -123,8 +123,12 @@ def update_config(config, args):
     config.defrost()
     if args.dataset:
         config.DATA.DATASET = args.dataset
+    if args.eval:
+        config.EVAL = True
     if args.batch_size:
         config.DATA.BATCH_SIZE = args.batch_size
+        if config.EVAL:
+            config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.image_size:
         config.DATA.IMAGE_SIZE = args.image_size
     if args.data_path:
@@ -133,9 +137,6 @@ def update_config(config, args):
         config.SAVE = args.output
     if args.ngpus:
         config.NGPUS = args.ngpus
-    if args.eval:
-        config.EVAL = True
-        config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.pretrained:
         config.MODEL.PRETRAINED = args.pretrained
     if args.resume:

--- a/image_classification/XCiT/config.py
+++ b/image_classification/XCiT/config.py
@@ -153,8 +153,12 @@ def update_config(config, args):
     config.defrost()
     if args.dataset:
         config.DATA.DATASET = args.dataset
+    if args.eval:
+        config.EVAL = True
     if args.batch_size:
         config.DATA.BATCH_SIZE = args.batch_size
+        if config.EVAL:
+            config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.image_size:
         config.DATA.IMAGE_SIZE = args.image_size
     if args.data_path:
@@ -163,9 +167,6 @@ def update_config(config, args):
         config.SAVE = args.output
     if args.ngpus:
         config.NGPUS = args.ngpus
-    if args.eval:
-        config.EVAL = True
-        config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.pretrained:
         config.MODEL.PRETRAINED = args.pretrained
     if args.resume:

--- a/image_classification/gMLP/config.py
+++ b/image_classification/gMLP/config.py
@@ -117,8 +117,12 @@ def update_config(config, args):
     config.defrost()
     if args.dataset:
         config.DATA.DATASET = args.dataset
+    if args.eval:
+        config.EVAL = True
     if args.batch_size:
         config.DATA.BATCH_SIZE = args.batch_size
+        if config.EVAL:
+            config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.image_size:
         config.DATA.IMAGE_SIZE = args.image_size
     if args.data_path:
@@ -127,9 +131,6 @@ def update_config(config, args):
         config.SAVE = args.output
     if args.ngpus:
         config.NGPUS = args.ngpus
-    if args.eval:
-        config.EVAL = True
-        config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.pretrained:
         config.MODEL.PRETRAINED = args.pretrained
     if args.resume:

--- a/object_detection/DETR/config.py
+++ b/object_detection/DETR/config.py
@@ -117,15 +117,16 @@ def update_config(config, args):
     config.defrost()
     if args.dataset:
         config.DATA.DATASET = args.dataset
+    if args.eval:
+        config.EVAL = True
     if args.batch_size:
         config.DATA.BATCH_SIZE = args.batch_size
+        if config.EVAL:
+            config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.data_path:
         config.DATA.DATA_PATH = args.data_path
     if args.ngpus:
         config.NGPUS = args.ngpus
-    if args.eval:
-        config.EVAL = True
-        config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.pretrained:
         config.MODEL.PRETRAINED = args.pretrained
     if args.backbone:

--- a/object_detection/PVTv2/config.py
+++ b/object_detection/PVTv2/config.py
@@ -195,15 +195,16 @@ def update_config(config, args):
     config.defrost()
     if args.dataset:
         config.DATA.DATASET = args.dataset
+    if args.eval:
+        config.EVAL = True
     if args.batch_size:
         config.DATA.BATCH_SIZE = args.batch_size
+        if config.EVAL:
+            config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.data_path:
         config.DATA.DATA_PATH = args.data_path
     if args.ngpus:
         config.NGPUS = args.ngpus
-    if args.eval:
-        config.EVAL = True
-        config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.pretrained:
         config.MODEL.PRETRAINED = args.pretrained
     if args.resume:

--- a/object_detection/Swin/config.py
+++ b/object_detection/Swin/config.py
@@ -196,15 +196,16 @@ def update_config(config, args):
     config.defrost()
     if args.dataset:
         config.DATA.DATASET = args.dataset
+    if args.eval:
+        config.EVAL = True
     if args.batch_size:
         config.DATA.BATCH_SIZE = args.batch_size
+        if config.EVAL:
+            config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.data_path:
         config.DATA.DATA_PATH = args.data_path
     if args.ngpus:
         config.NGPUS = args.ngpus
-    if args.eval:
-        config.EVAL = True
-        config.DATA.BATCH_SIZE_EVAL = args.batch_size
     if args.pretrained:
         config.MODEL.PRETRAINED = args.pretrained
     if args.resume:


### PR DESCRIPTION
https://github.com/BR-IDL/PaddleViT/blob/de1ad11c0e7865570d0ab1ac4dfb56c3b3699899/image_classification/BEiT/config.py#L165-L167

目前 eval mode 如果不通过参数指定 batch_size，由于没有对 args.batch_size 值进行校验，会将默认值 None 传给 `BATCH_SIZE_EVAL`，因此对该逻辑进行了修正～